### PR TITLE
[Backport] Alignement Array assignement

### DIFF
--- a/app/code/Magento/Store/Setup/InstallSchema.php
+++ b/app/code/Magento/Store/Setup/InstallSchema.php
@@ -270,7 +270,13 @@ class InstallSchema implements InstallSchemaInterface
          */
         $connection->insertForce(
             $installer->getTable('store_group'),
-            ['group_id' => 0, 'website_id' => 0, 'name' => 'Default', 'root_category_id' => 0, 'default_store_id' => 0]
+            [
+                'group_id' => 0, 
+                'website_id' => 0, 
+                'name' => 'Default', 
+                'root_category_id' => 0, 
+                'default_store_id' => 0
+            ]
         );
         $connection->insertForce(
             $installer->getTable('store_group'),

--- a/app/code/Magento/Store/Setup/InstallSchema.php
+++ b/app/code/Magento/Store/Setup/InstallSchema.php
@@ -271,10 +271,10 @@ class InstallSchema implements InstallSchemaInterface
         $connection->insertForce(
             $installer->getTable('store_group'),
             [
-                'group_id' => 0, 
-                'website_id' => 0, 
-                'name' => 'Default', 
-                'root_category_id' => 0, 
+                'group_id' => 0,
+                'website_id' => 0,
+                'name' => 'Default',
+                'root_category_id' => 0,
                 'default_store_id' => 0
             ]
         );


### PR DESCRIPTION
For Your Eyes Only

### Description

According to the formatting Array assignement for insertion `website_id:1` in `store_website` table, the values for insertion `website_id:0`:
```
/**
 * Insert store groups
 */
$connection->insertForce(
    $installer->getTable('store_group'),
    ['group_id' => 0, 'website_id' => 0, 'name' => 'Default', 'root_category_id' => 0, 'default_store_id' => 0]
);
$connection->insertForce(
    $installer->getTable('store_group'),
    [
        'group_id' => 1,
        'website_id' => 1,
        'name' => 'Main Website Store',
        'root_category_id' => $this->getDefaultCategory()->getId(),
        'default_store_id' => 1
    ]
);
```
become

```
/**
 * Insert store groups
 */
$connection->insertForce(
    $installer->getTable('store_group'),
    [
        'group_id' => 0, 
        'website_id' => 0, 
        'name' => 'Default', 
        'root_category_id' => 0, 
        'default_store_id' => 0
    ]
);
$connection->insertForce(
    $installer->getTable('store_group'),
    [
        'group_id' => 1,
        'website_id' => 1,
        'name' => 'Main Website Store',
        'root_category_id' => $this->getDefaultCategory()->getId(),
        'default_store_id' => 1
    ]
);
```

### Fixed Issues 

Remove ugly code because ...
All Codes Are Beautiful

### Manual testing scenarios

1. Open file in text editor

2. Just watch the lines from 268 to 290 and relax 

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
