### PR TITLE
[Forwardport] Prevents to generate an empty string for url rewrite

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php
@@ -124,7 +124,8 @@ class ProductUrlPathGenerator
      */
     public function getUrlKey($product)
     {
-        return $product->getUrlKey() === false ? false : $this->prepareProductUrlKey($product);
+        $usesDefaultValue = $product->getUrlKey() === false || $product->getUrlKey() === null;
+        return $usesDefaultValue ? false : $this->prepareProductUrlKey($product);
     }
 
     /**

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductUrlPathGeneratorTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductUrlPathGeneratorTest.php
@@ -105,7 +105,7 @@ class ProductUrlPathGeneratorTest extends \PHPUnit\Framework\TestCase
     {
         $this->product->expects($this->any())->method('getUrlKey')->will($this->returnValue($productUrlKey));
         $this->product->expects($this->any())->method('formatUrlKey')->will($this->returnValue($productUrlKey));
-        $this->assertEquals($expectedUrlKey, $this->productUrlPathGenerator->getUrlKey($this->product));
+        $this->assertSame($expectedUrlKey, $this->productUrlPathGenerator->getUrlKey($this->product));
     }
 
     /**
@@ -115,6 +115,7 @@ class ProductUrlPathGeneratorTest extends \PHPUnit\Framework\TestCase
     {
         return [
             'URL Key use default' => [false, false],
+            'URL Key use default from admin' => [null, false],
             'URL Key empty' => ['product-url', 'product-url'],
         ];
     }


### PR DESCRIPTION
… when using default value from store view in admin

### Description

This PR is a fix for invalid `Use Default Value` saved from the admin on product url key, because the value of `$product->getUrlKey()` is `null` instead of `false`

### Fixed Issues (if relevant)

It seems that the same fix (maybe at another abstraction level) might apply to

1. https://github.com/magento/magento2/issues/12982
2. https://github.com/magento/magento2/issues/10424
3. https://github.com/magento/magento2/issues/12159#issuecomment-343528601

### Manual testing scenarios

1. AS An Admin, create 2 store views
2. Create a product
3. Change the url key at a store level and save the product
4. Edit the product to recheck the `Use Default Value` checkbox

What happens (without this patch):

![selection_003](https://user-images.githubusercontent.com/75968/36024666-b6b2ea60-0d90-11e8-8ea0-769e4f4013a0.png)

What happens (with this patch):

![selection_002](https://user-images.githubusercontent.com/75968/36024677-bfd1d110-0d90-11e8-90d9-7218694d8f21.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### More

If you think it could be useful to fix a more general issue with EAV `Use Default Value`, let me know and I could spend more time on a fix.
 ### Original PR 
 https://github.com/magento/magento2/pull/13581